### PR TITLE
fix sql-functions tests and add a new UDF

### DIFF
--- a/sql-functions/src/main/java/com/ververica/platform/sql/functions/Obfuscate.java
+++ b/sql-functions/src/main/java/com/ververica/platform/sql/functions/Obfuscate.java
@@ -1,0 +1,51 @@
+package com.ververica.platform.sql.functions;
+
+import java.math.BigInteger;
+import java.security.MessageDigest;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.apache.flink.table.functions.FunctionContext;
+import org.apache.flink.table.functions.ScalarFunction;
+
+/**
+ * Obfuscates names and emails (only the part before the '@') by replying them with their short md5
+ * hash (6 characters).
+ */
+@SuppressWarnings("unused")
+public class Obfuscate extends ScalarFunction {
+
+  private transient MessageDigest md5;
+
+  @Override
+  public void open(FunctionContext context) throws Exception {
+    this.md5 = MessageDigest.getInstance("MD5");
+  }
+
+  private String md5Short(String input) {
+    md5.update(input.getBytes());
+    return String.format("%032x", new BigInteger(1, md5.digest())).substring(0, 6);
+  }
+
+  private String obfuscateEmailAddress(String emailAddress) {
+    if (emailAddress != null) {
+      String[] components = emailAddress.split("@", 2);
+      if (components.length == 2) {
+        return md5Short(components[0]) + "@" + components[1];
+      } else if (components.length == 1) {
+        return md5Short(components[0]);
+      } else {
+        return null;
+      }
+    } else {
+      return null;
+    }
+  }
+
+  public String eval(String emailAddress) {
+    return obfuscateEmailAddress(emailAddress);
+  }
+
+  public List<String> eval(List<String> emailAddresss) {
+    return emailAddresss.stream().map(this::obfuscateEmailAddress).collect(Collectors.toList());
+  }
+}

--- a/sql-functions/src/test/java/com/ververica/platform/sql/functions/ArrayListAggFunctionITCase.java
+++ b/sql-functions/src/test/java/com/ververica/platform/sql/functions/ArrayListAggFunctionITCase.java
@@ -37,6 +37,7 @@ public class ArrayListAggFunctionITCase {
 
   @Before
   public void setUp() {
+    TestValuesTableFactory.clearAllData();
     env = StreamExecutionEnvironment.getExecutionEnvironment();
     env.setParallelism(4);
     tEnv =

--- a/sql-functions/src/test/java/com/ververica/platform/sql/functions/GetEmailAliasesAndCompanyITCase.java
+++ b/sql-functions/src/test/java/com/ververica/platform/sql/functions/GetEmailAliasesAndCompanyITCase.java
@@ -26,6 +26,7 @@ public class GetEmailAliasesAndCompanyITCase {
 
   @Before
   public void setUp() {
+    TestValuesTableFactory.clearAllData();
     env = StreamExecutionEnvironment.getExecutionEnvironment();
     env.setParallelism(4);
     tEnv =

--- a/sql-functions/src/test/java/com/ververica/platform/sql/functions/LargestStringArrayAggFunctionITCase.java
+++ b/sql-functions/src/test/java/com/ververica/platform/sql/functions/LargestStringArrayAggFunctionITCase.java
@@ -26,6 +26,7 @@ public class LargestStringArrayAggFunctionITCase {
 
   @Before
   public void setUp() {
+    TestValuesTableFactory.clearAllData();
     env = StreamExecutionEnvironment.getExecutionEnvironment();
     env.setParallelism(4);
     tEnv =

--- a/sql-functions/src/test/java/com/ververica/platform/sql/functions/LastValueStringArrayAggFunctionITCase.java
+++ b/sql-functions/src/test/java/com/ververica/platform/sql/functions/LastValueStringArrayAggFunctionITCase.java
@@ -26,6 +26,7 @@ public class LastValueStringArrayAggFunctionITCase {
 
   @Before
   public void setUp() {
+    TestValuesTableFactory.clearAllData();
     env = StreamExecutionEnvironment.getExecutionEnvironment();
     env.setParallelism(4);
     tEnv =

--- a/sql-functions/src/test/java/com/ververica/platform/sql/functions/ObfuscateITCase.java
+++ b/sql-functions/src/test/java/com/ververica/platform/sql/functions/ObfuscateITCase.java
@@ -1,0 +1,133 @@
+package com.ververica.platform.sql.functions;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import org.apache.flink.api.common.restartstrategy.RestartStrategies;
+import org.apache.flink.contrib.streaming.state.RocksDBStateBackend;
+import org.apache.flink.runtime.state.StateBackend;
+import org.apache.flink.runtime.state.memory.MemoryStateBackend;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.table.api.EnvironmentSettings;
+import org.apache.flink.table.api.TableResult;
+import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
+import org.apache.flink.table.planner.factories.TestValuesTableFactory;
+import org.apache.flink.types.Row;
+import org.apache.flink.types.RowKind;
+import org.apache.flink.util.CloseableIterator;
+import org.junit.Before;
+import org.junit.Test;
+
+/** Integration test for {@link Obfuscate}. */
+public class ObfuscateITCase {
+
+  protected StreamExecutionEnvironment env;
+  protected StreamTableEnvironment tEnv;
+
+  @Before
+  public void setUp() {
+    env = StreamExecutionEnvironment.getExecutionEnvironment();
+    env.setParallelism(4);
+    tEnv =
+        StreamTableEnvironment.create(
+            env, EnvironmentSettings.newInstance().useBlinkPlanner().inStreamingMode().build());
+    env.getConfig().setRestartStrategy(RestartStrategies.noRestart());
+    env.setStateBackend(new RocksDBStateBackend((StateBackend) new MemoryStateBackend()));
+
+    tEnv.createTemporaryFunction("Obfuscate", Obfuscate.class);
+  }
+
+  private void createSource(String type, Row... inputData) {
+    final String createSource =
+        String.format(
+            "CREATE TABLE input ( \n"
+                + "  `field` "
+                + type
+                + "\n"
+                + ") WITH (\n"
+                + "  'connector' = 'values',\n"
+                + "  'data-id' = '%s'\n"
+                + ")",
+            TestValuesTableFactory.registerData(Arrays.asList(inputData)));
+    tEnv.executeSql(createSource);
+  }
+
+  private ArrayList<Row> executeSql() throws Exception {
+    TableResult resultTable = tEnv.executeSql("SELECT Obfuscate(field) FROM input");
+
+    ArrayList<Row> resultList = new ArrayList<>();
+    try (CloseableIterator<Row> it = resultTable.collect()) {
+      it.forEachRemaining(resultList::add);
+    }
+    return resultList;
+  }
+
+  @Test
+  public void testNameString1() throws Exception {
+    createSource("STRING", Row.of("john"), Row.of("alice"), Row.of("bob"));
+
+    List<Row> rawResult = executeSql();
+
+    assertThat(
+        rawResult,
+        containsInAnyOrder(
+            Row.ofKind(RowKind.INSERT, "527bd5"),
+            Row.ofKind(RowKind.INSERT, "6384e2"),
+            Row.ofKind(RowKind.INSERT, "9f9d51")));
+  }
+
+  @Test
+  public void testNameArray1() throws Exception {
+    createSource(
+        "ARRAY<STRING>",
+        Row.of((Object) new String[] {"john"}),
+        Row.of((Object) new String[] {"alice", "alice"}),
+        Row.of((Object) new String[] {"bob"}));
+
+    List<Row> rawResult = executeSql();
+
+    assertThat(
+        rawResult,
+        containsInAnyOrder(
+            Row.ofKind(RowKind.INSERT, (Object) new String[] {"527bd5"}),
+            Row.ofKind(RowKind.INSERT, (Object) new String[] {"6384e2", "6384e2"}),
+            Row.ofKind(RowKind.INSERT, (Object) new String[] {"9f9d51"})));
+  }
+
+  @Test
+  public void testEmailString1() throws Exception {
+    createSource(
+        "STRING", Row.of("john@test.com"), Row.of("alice@test.com"), Row.of("bob@test.com"));
+
+    List<Row> rawResult = executeSql();
+
+    assertThat(
+        rawResult,
+        containsInAnyOrder(
+            Row.ofKind(RowKind.INSERT, "527bd5@test.com"),
+            Row.ofKind(RowKind.INSERT, "6384e2@test.com"),
+            Row.ofKind(RowKind.INSERT, "9f9d51@test.com")));
+  }
+
+  @Test
+  public void testEmailArray1() throws Exception {
+    createSource(
+        "ARRAY<STRING>",
+        Row.of((Object) new String[] {"john@test.com"}),
+        Row.of((Object) new String[] {"alice@test.com", "alice@apache.org"}),
+        Row.of((Object) new String[] {"bob@test2.com"}));
+
+    List<Row> rawResult = executeSql();
+
+    assertThat(
+        rawResult,
+        containsInAnyOrder(
+            Row.ofKind(RowKind.INSERT, (Object) new String[] {"527bd5@test.com"}),
+            Row.ofKind(
+                RowKind.INSERT, (Object) new String[] {"6384e2@test.com", "6384e2@apache.org"}),
+            Row.ofKind(RowKind.INSERT, (Object) new String[] {"9f9d51@test2.com"})));
+  }
+}


### PR DESCRIPTION
This PR contains two commits to:
- fix `TestValuesTableFactory` not being cleared before use (it stores results in static fields)
- add the new `Obfuscate` scalar UDF